### PR TITLE
add 'inc' method to patchbuilder

### DIFF
--- a/lib/patch.js
+++ b/lib/patch.js
@@ -88,8 +88,12 @@ PatchBuilder.prototype.test = function (path, value) {
  */
 PatchBuilder.prototype.inc = function (path, value) {
   assert(path, 'Inc requires a path parameter.');
-  assert(value, 'Inc requires a path parameter.');
-  this._ops.push({"op": "inc", "path": path, "value": value});
+  var op = {
+    op: "inc",
+    path: path,
+  };
+  if (value) op.value = value;
+  this._ops.push(op);
   return this;
 };
 

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -82,6 +82,18 @@ PatchBuilder.prototype.test = function (path, value) {
 };
 
 /**
+ * Increase the value at the specified JSON document path by the given number
+ * @param {string} path - JSON document path; delimtied by periods or slashes
+ * @param {Object} value - Number by which to increase the value
+ */
+PatchBuilder.prototype.inc = function (path, value) {
+  assert(path, 'Inc requires a path parameter.');
+  assert(value, 'Inc requires a path parameter.');
+  this._ops.push({"op": "inc", "path": path, "value": value});
+  return this;
+};
+
+/**
  * return {Promise}
  */
 PatchBuilder.prototype.apply = function (match) {


### PR DESCRIPTION
the `PatchBuilder` object does not currently support all patch operations. this pr fixes that.

unfortunately, the entire patch module currently lacks tests. i'll fix that in a future pr.