### PR TITLE
Added a new 'time_zone' param for 'time_series' aggregates

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -14,8 +14,8 @@ var BucketBuilder = require('./bucket_builder');
  */
 function SearchBuilder () {}
 
-
-require('util').inherits(SearchBuilder, Builder)
+var util = require('util');
+util.inherits(SearchBuilder, Builder)
 
 
 /**
@@ -74,13 +74,17 @@ SearchBuilder.prototype.sort = function (field, order) {
  * Add new aggregate parameter.
  * @param {string} type
  * @param {string} path
- * @param {string} value
+ * @param {array} args
  * @return {SearchBuilder}
  */
-SearchBuilder.prototype.aggregate = function (type, path, value) {
+SearchBuilder.prototype.aggregate = function (type, path, args) {
   assert(type, 'type required');
   assert(path, 'path required');
-  var _aggregate = [path, type, value].join(':');
+  var parts = [ path, type ];
+  if (typeof(args) === "string" || util.isArray(args)) {
+    parts = parts.concat(args);
+  }
+  var _aggregate = parts.join(':');
   if (this._aggregate) 
     this._aggregate = [this._aggregate, _aggregate].join(',');
   else
@@ -134,14 +138,26 @@ SearchBuilder.prototype.distance = function (path, buckets) {
  }
 
  /**
- * Add new 'time_series' aggregate parameter.
+ * Add new 'time_series' aggregate parameter. The 'time' param, which must be
+ * one of ('year', 'quarter', 'month', 'week', 'day', or 'hour'), determines
+ * the bucketing interval for the time-series. The optional timezone param,
+ * if present, must begin with a "+" or "-" character, followed by four digits
+ * representing the hours and minutes of offset, relative to UTC. For example,
+ * Eastern Standard Time (EST) would be represented as "-0500", since the time
+ * in EST is five hours behind that of UTC.
+ *
  * @param {string} type
  * @param {string} path
- * @param {string} value
+ * @param {string} time
+ * @param {string} timezone
  * @return {SearchBuilder}
  */
- SearchBuilder.prototype.time_series = function (path, time) {
-  return this.aggregate('time_series', path, time);
+ SearchBuilder.prototype.time_series = function (path, time, timezone) {
+  if (typeof(timezone) === "undefined") {
+    return this.aggregate('time_series', path, time);
+  } else {
+    return this.aggregate('time_series', path, [ time, timezone ]);
+  }
  }
 
 /**

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -120,6 +120,7 @@ suite('Search', function () {
       .after(2);
     })
     .time_series('path', 'day')
+    .time_series('path', 'hour', '+0900')
     .query('value.location:NEAR:{latitude:12.3 longitude:56.7 radius:100km}')
     .then(function (res) {
       assert.equal(200, res.statusCode);


### PR DESCRIPTION
Time-series aggregates can now be adjusted to use interval boundaries in your favorite time-zone (instead of the default UTC).