### PR TITLE
Cross-collection search for all object kinds (item, event, relationship)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -232,6 +232,20 @@ Client.prototype.search = function (collection, query, options) {
 
 
 /**
+ * Search across collections by key.
+ * @param {string} query
+ * @param {Object} options (Optional)
+ * @return {Promise}
+ */
+Client.prototype.searchAcrossCollections = function (query, options) {
+  assert(query, 'Query required.')
+  options = options || {}
+  options.query = query;
+  return this._get(this.generateApiUrl([], options))
+}
+
+
+/**
  * Check if key is valid.
  * @return {Promise}
  */

--- a/lib/search.js
+++ b/lib/search.js
@@ -194,7 +194,7 @@ SearchBuilder.prototype.distance = function (path, buckets) {
    assert(arguments.length > 0, 'At least one kind required.')
    for (var i=0; i<arguments.length; i++) {
      var kind = arguments[i]
-     assert(kind === 'event' || kind === 'item', "'event' or 'item' required.")
+     assert(kind === 'event' || kind === 'item' || kind === 'relationship', "'item', 'event', or 'relationship' required.")
      kinds.push(kind)
    }
    this._kinds = kinds
@@ -220,8 +220,11 @@ SearchBuilder.prototype.query = function (query) {
  * @protected
  */
 SearchBuilder.prototype._execute = function (method) {
-  assert(this._collection && this._query, 'Collection and query required.')
-  var pathArgs = [this._collection]
+  assert(this._query, 'Query required.')
+  var pathArgs = []
+  if (this._collection) {
+    pathArgs.push(this._collection);
+  }
   var query = this._query
   if (this._kinds) {
     query = '@path.kind:('+this._kinds.join(' ')+') AND (' + this._query + ')'

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -22,7 +22,7 @@ suite('Search', function () {
     });
   });
 
-    // Basic search
+  // Basic search
   test('Basic search', function (done) {
     db.newSearchBuilder()
       .collection(users.collection)
@@ -30,6 +30,21 @@ suite('Search', function () {
       .then(function (res) {
         assert.equal(200, res.statusCode);
         assert.equal(2, res.body.count);
+        done();
+      })
+      .fail(function (res) {
+        done(res);
+      });
+  });
+
+  // Cross-collection search (find all items in the 'users' collections, via query clause)
+  test('Cross-collection search', function (done) {
+    db.newSearchBuilder()
+      .limit(10)
+      .query('@path.collection:`' + users.collection + '`')
+      .then(function (res) {
+        assert.equal(200, res.statusCode);
+        assert.equal(3, res.body.count);
         done();
       })
       .fail(function (res) {


### PR DESCRIPTION
Search across all collections:

```
db.searchAcrossCollections('query')
   .then(function (result) {
      // do stuff
   })
   .fail(function (err) {
      // do stuff
   })
```

Or use the SearchBuilder, searching across collections by omitting the `collection(string)` function from your SearchBuilder call:

```
db.newSearchBuilder()
   .limit(100)
   .offset(10)
   .query('steve')
```

The search API now allows you to search for graph relationships, by passing the `relationship` string into the `kinds(string)` builder function:

```
db.newSearchBuilder()
   .limit(100)
   .offset(10)
   .kinds("relationship")
   .query('@path.source.collection:`my_collection` AND value.foo:bar')
```